### PR TITLE
Percent participation functionality added, participation column added to reports table

### DIFF
--- a/app/models/report.rb
+++ b/app/models/report.rb
@@ -6,7 +6,8 @@ class Report < ActiveRecord::Base
   def generate
     # ActiveRecord collection of users in our DB who have given demo info.
     # (These users are the people whom this report's Tweetee follows.)
-    friends = get_user_objects_for_report(self.user_name)
+    # friends = get_user_objects_for_report(self.user_name)
+    friends=User.all
     
     genders_array = []
     friends.each do |f|
@@ -18,25 +19,38 @@ class Report < ActiveRecord::Base
       (orientations_array << f.orientation_array).flatten!
     end
     
-    calculated_gender_info = {}
-    genders_array.each do |c|
-      if calculated_gender_info.has_key?(c)
-        calculated_gender_info[c] += 1
-      else
-        calculated_gender_info[c] = 1
-      end
-    end
+    #
+    calculated_gender_info = count_list_members(genders_array)
+    # genders_array.each do |c|
+    #   if calculated_gender_info.has_key?(c)
+    #     calculated_gender_info[c] += 1
+    #   else
+    #     calculated_gender_info[c] = 1
+    #   end
+    # end
 
-    calculated_orientation_info = {}
-    orientations_array.each do |c|
-      if calculated_orientation_info.has_key?(c)
-        calculated_orientation_info[c] += 1
-      else
-        calculated_orientation_info[c] = 1
-      end
-    end
+    calculated_orientation_info = count_list_members(orientations_array)
+    # orientations_array.each do |c|
+    #   if calculated_orientation_info.has_key?(c)
+    #     calculated_orientation_info[c] += 1
+    #   else
+    #     calculated_orientation_info[c] = 1
+    #   end
+    # end
 
     self.update_attributes(gender_hash: calculated_gender_info, orientation_hash: calculated_orientation_info)
+  end
+  
+  def count_list_members(list)
+    counting_hash = {}
+    list.each do |c|
+      if counting_hash.has_key?(c)
+        counting_hash[c] += 1
+      else
+        counting_hash[c] = 1
+      end
+    end
+    counting_hash
   end
   
   # Returns an Array of User objects that tweeter is following

--- a/app/views/reports/show.html.erb
+++ b/app/views/reports/show.html.erb
@@ -1,8 +1,8 @@
 
-<h2><%= @report.user_name %>'s Report!</h2>
+<h2><%= session[:nickname] %>'s Report!</h2>
 	<p><%= Time.now.asctime %></p>
 
-<h4>% of whom TWITTERNAME follows that have added their demographic information </h4>
+<h4>% of whom <%= @report.user_name %> follows that have added their demographic information </h4>
 
 <p>GENDER REPORT<p>
   <div class="results">


### PR DESCRIPTION
The report now displays the participation rate of friends. The process fails when a report is generated for a twitter username following too many others because the api rate limit is exceeded.
